### PR TITLE
updated ci actions

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,17 +35,17 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.9'
@@ -53,6 +53,6 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -55,4 +55,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheelhouse-${{ matrix.os }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Bumped actions versions
Fixed artifacts uploading

Also we need specify which msvc version will be used with cibuildwheel, cause current is 2022 but libusb uses 2019 and the gh workflows can use 2022 unexpectedly

probably can be done with
```
      matrix:
        os:
          - ubuntu-latest
          - macos-latest
          - windows-2019
```